### PR TITLE
Sort subnets and add 2 new subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ IPs(subnets) used by Yandex Home(Alice)
 I wrote down all the addresses from which Yandex Home submitted requests. Then I checked through WHOIS the service to whom the IP belongs and the subnet.
 
 ```
-37.140.152.128/25
-5.255.199.0/26
-37.9.87.96/27
-5.45.235.64/26
-37.9.87.0/26
-5.45.207.0/24
-141.8.142.0/24
-5.255.253.0/24
-37.9.68.128/26
+allow 5.45.207.0/24;
+allow 5.45.235.64/26;
+allow 5.255.199.0/26;
+allow 5.255.228.0/24;
+allow 5.255.253.0/24;
+allow 37.9.68.128/26;
+allow 37.9.87.0/26;
+allow 37.9.87.96/27;
+allow 37.140.152.128/25;
+allow 141.8.129.0/24;
+allow 141.8.142.0/24;
 ```
 Google Home adresses: https://github.com/allmazz/google_home_ip


### PR DESCRIPTION
Added 2 new subnets used by Yandex for smart home integrations: 5.255.228.0/24 and 141.8.129.0/24. Ip adresses from both networks was checked by whois service. I also sorted subnets by name.